### PR TITLE
Remove Buffer REST API

### DIFF
--- a/generated_providers.json
+++ b/generated_providers.json
@@ -659,15 +659,6 @@
     "token_site": "https://platform.brexapis.com"
   },
   {
-    "keyname": "buffer",
-    "display_name": "Buffer",
-    "category": "marketing",
-    "authorize_url": "https://bufferapp.com/oauth2/authorize",
-    "token_url": "https://api.bufferapp.com/1/oauth2/token.json",
-    "pkce_enabled": "no",
-    "notes": "Profile endpoint: https://api.bufferapp.com/1/user.json"
-  },
-  {
     "keyname": "bullhorn",
     "display_name": "Bullhorn",
     "category": "hr",


### PR DESCRIPTION
We're working on a new API at Buffer.  Our REST API is deprecated. 

We can add a new provider with the new API soon.

## Checklist

- [x] YAML is valid
- [x] Required fields present (`keyname`, `display_name`, `category`, `authorize_url`, `token_url`, `pkce_enabled`)
- [x] `keyname` is unique and lowercase-hyphenated
- [x] `category` is from the valid list
- [x] Tested OAuth flow or linked to provider's OAuth documentation

## Provider(s)

<!-- List the provider(s) added or modified -->

## OAuth Documentation

<!-- Link to the provider's OAuth/API documentation -->
