### PR TITLE
add Enphase Energy

### DIFF
--- a/generated_providers.json
+++ b/generated_providers.json
@@ -659,6 +659,15 @@
     "token_site": "https://platform.brexapis.com"
   },
   {
+    "keyname": "buffer",
+    "display_name": "Buffer",
+    "category": "marketing",
+    "authorize_url": "https://bufferapp.com/oauth2/authorize",
+    "token_url": "https://api.bufferapp.com/1/oauth2/token.json",
+    "pkce_enabled": "no",
+    "notes": "Profile endpoint: https://api.bufferapp.com/1/user.json"
+  },
+  {
     "keyname": "bullhorn",
     "display_name": "Bullhorn",
     "category": "hr",
@@ -1253,6 +1262,19 @@
     "token_url": "https://oauth.employmenthero.com/oauth2/token",
     "pkce_enabled": "no",
     "token_site": "https://api.employmenthero.com/api"
+  },
+  {
+    "keyname": "enphase",
+    "display_name": "Enphase Energy",
+    "category": "smart-home",
+    "authorize_url": "https://api.enphaseenergy.com/oauth/authorize",
+    "token_url": "https://api.enphaseenergy.com/oauth/token",
+    "pkce_enabled": "no",
+    "token_request_auth_method": "header",
+    "authorization_method": "header",
+    "help_url": "https://developer-v4.enphase.com/docs/quickstart.html",
+    "verification_endpoint": "https://api.enphaseenergy.com/api/v4/systems",
+    "notes": "Requires an API key in addition to OAuth: append your app key as a query param to every request, e.g. https://api.enphaseenergy.com/api/v4/systems?key=YOUR_API_KEY. Find your system_id from that endpoint. Token exchange and refresh use HTTP Basic auth. Access tokens last 1 day, refresh tokens 1 month. Rate limits depend on your Enphase developer plan."
   },
   {
     "keyname": "envoy",

--- a/providers.yml
+++ b/providers.yml
@@ -1110,6 +1110,18 @@
   pkce_enabled: 'no'
   token_site: https://api.employmenthero.com/api
 
+- keyname: enphase
+  display_name: Enphase Energy
+  category: smart-home
+  authorize_url: https://api.enphaseenergy.com/oauth/authorize
+  token_url: https://api.enphaseenergy.com/oauth/token
+  pkce_enabled: 'no'
+  token_request_auth_method: 'header'
+  authorization_method: 'header'
+  help_url: https://developer-v4.enphase.com/docs/quickstart.html
+  verification_endpoint: https://api.enphaseenergy.com/api/v4/systems
+  notes: 'Requires an API key in addition to OAuth: append your app key as a query param to every request, e.g. https://api.enphaseenergy.com/api/v4/systems?key=YOUR_API_KEY. Find your system_id from that endpoint. Token exchange and refresh use HTTP Basic auth. Access tokens last 1 day, refresh tokens 1 month. Rate limits depend on your Enphase developer plan.'
+
 - keyname: envoy
   display_name: Envoy
   category: productivity


### PR DESCRIPTION
their API's free plan is too limiting for our native plugin. this gets us 1 step closer to a forkable Recipe for bring-your-own-keys. https://trmnl.com/integrations/enphase

## Checklist

- [x] YAML is valid
- [x] Required fields present (`keyname`, `display_name`, `category`, `authorize_url`, `token_url`, `pkce_enabled`)
- [x] `keyname` is unique and lowercase-hyphenated
- [x] `category` is from the valid list
- [x] Tested OAuth flow or linked to provider's OAuth documentation

## Provider(s)

Enphase Energy

## OAuth Documentation

https://developer-v4.enphase.com/
